### PR TITLE
fix: update rates to be more realistic

### DIFF
--- a/trading/bot.go
+++ b/trading/bot.go
@@ -65,33 +65,71 @@ func placeOrders() error {
 
 	orders := []placeOrderParameters{
 		{
-			price:    0.005,
-			quantity: 0.01,
+			price:    0.7,
+			quantity: 0.003,
 			side:     xudrpc.OrderSide_BUY,
 		},
 		{
-			price:    0.01,
-			quantity: 0.01,
+			price:    0.75,
+			quantity: 0.0025,
+			side:     xudrpc.OrderSide_BUY,
+		},
+		{
+			price:    0.8,
+			quantity: 0.002,
+			side:     xudrpc.OrderSide_BUY,
+		},
+		{
+			price:    0.85,
+			quantity: 0.0015,
+			side:     xudrpc.OrderSide_BUY,
+		},
+		{
+			price:    0.9,
+			quantity: 0.001,
+			side:     xudrpc.OrderSide_BUY,
+		},
+
+		{
+			price:    1.1,
+			quantity: 0.001,
+			side:     xudrpc.OrderSide_SELL,
+		},
+		{
+			price:    1.15,
+			quantity: 0.0015,
+			side:     xudrpc.OrderSide_SELL,
+		},
+		{
+			price:    1.2,
+			quantity: 0.002,
+			side:     xudrpc.OrderSide_SELL,
+		},
+		{
+			price:    1.25,
+			quantity: 0.0025,
+			side:     xudrpc.OrderSide_SELL,
+		},
+		{
+			price:    1.3,
+			quantity: 0.003,
 			side:     xudrpc.OrderSide_SELL,
 		},
 	}
 
 	var err error
 
-	// Add each order five times
 	for _, order := range orders {
-		for i := 0; i < 5; i++ {
-			wg.Add(1)
+		wg.Add(1)
 
-			go func(order placeOrderParameters) {
-				placeErr := placeOrder(order)
-				if placeErr != nil {
-					err = placeErr
-				}
+		go func(order placeOrderParameters) {
+			placeErr := placeOrder(order)
+			if placeErr != nil {
+				err = placeErr
+			}
 
-				wg.Done()
-			}(order)
-		}
+			wg.Done()
+		}(order)
 	}
 
 	wg.Wait()

--- a/trading/bot.go
+++ b/trading/bot.go
@@ -65,12 +65,12 @@ func placeOrders() error {
 
 	orders := []placeOrderParameters{
 		{
-			price:    0.001,
+			price:    0.005,
 			quantity: 0.01,
 			side:     xudrpc.OrderSide_BUY,
 		},
 		{
-			price:    0.002,
+			price:    0.01,
 			quantity: 0.01,
 			side:     xudrpc.OrderSide_SELL,
 		},

--- a/trading/bot.go
+++ b/trading/bot.go
@@ -65,22 +65,22 @@ func placeOrders() error {
 
 	orders := []placeOrderParameters{
 		{
-			price:    0.7,
+			price:    0.86,
 			quantity: 0.003,
 			side:     xudrpc.OrderSide_BUY,
 		},
 		{
-			price:    0.75,
+			price:    0.87,
 			quantity: 0.0025,
 			side:     xudrpc.OrderSide_BUY,
 		},
 		{
-			price:    0.8,
+			price:    0.88,
 			quantity: 0.002,
 			side:     xudrpc.OrderSide_BUY,
 		},
 		{
-			price:    0.85,
+			price:    0.89,
 			quantity: 0.0015,
 			side:     xudrpc.OrderSide_BUY,
 		},
@@ -96,22 +96,22 @@ func placeOrders() error {
 			side:     xudrpc.OrderSide_SELL,
 		},
 		{
-			price:    1.15,
+			price:    1.11,
 			quantity: 0.0015,
 			side:     xudrpc.OrderSide_SELL,
 		},
 		{
-			price:    1.2,
+			price:    1.12,
 			quantity: 0.002,
 			side:     xudrpc.OrderSide_SELL,
 		},
 		{
-			price:    1.25,
+			price:    1.13,
 			quantity: 0.0025,
 			side:     xudrpc.OrderSide_SELL,
 		},
 		{
-			price:    1.3,
+			price:    1.14,
 			quantity: 0.003,
 			side:     xudrpc.OrderSide_SELL,
 		},


### PR DESCRIPTION
The rate for `LTC/BTC` is `0,008036396` right now. I updated the rates of the orders a bit so that they are more like the real rate but still easy to type in.

What do you think? @offerm 